### PR TITLE
Fix alert API fetch handling

### DIFF
--- a/ascend_bot_vercel_template/api/alert.js
+++ b/ascend_bot_vercel_template/api/alert.js
@@ -4,7 +4,8 @@ module.exports = async (req, res) => {
   const phone = query.phone || "17865601891"; // Default phone
   const apiKey = query.apikey || "4709090"; // Replace with your actual key
 
-  const fetch = require('node-fetch');
+  // Use the global fetch implementation available in modern Node versions
+  const fetch = global.fetch || (await import('node-fetch')).default;
   const url = `https://api.callmebot.com/whatsapp.php?phone=${phone}&text=${encodeURIComponent(message)}&apikey=${apiKey}`;
 
   try {


### PR DESCRIPTION
## Summary
- use the built-in `fetch` when available and fall back to `node-fetch`

## Testing
- `node - <<'EOF'
const handler = require('./ascend_bot_vercel_template/api/alert.js');
handler({query:{}},{status:code=>({send:console.log})}).catch(console.error);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688246aa005c8320b154bdf622e09d31